### PR TITLE
Config

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -28,7 +28,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  host: db
+  host: <%= ENV.fetch("POSTGRES_HOST") { 'db' } %>
   database: itto_test
   
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -28,7 +28,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  host: <%= ENV.fetch("POSTGRES_HOST") { 'db' } %>
+  host: db
   database: itto_test
   
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  config.action_mailer.default_url_options = { host: Settings.development[:url] }
+  config.action_mailer.default_url_options = { host: "Settings.development[:url]" }
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
@@ -66,8 +66,8 @@ Rails.application.configure do
     :address => "smtp.gmail.com",
     :port => 587,
     :domain => 'smtp.gmail.com',
-    :user_name => Settings.development[:email], #先ほど作成した送信用Gmailアドレス
-    :password => Settings.development[:password], #2段階認証したアカウントで発行したアプリパスワード
+    :user_name => "Settings.development[:email]", #先ほど作成した送信用Gmailアドレス
+    :password => "Settings.development[:password]", #2段階認証したアカウントで発行したアプリパスワード
     :authentication => 'login'
   }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,7 +92,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = { host: Settings.production[:url] }
+  config.action_mailer.default_url_options = { host: "Settings.production[:url]" }
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
@@ -100,8 +100,8 @@ Rails.application.configure do
     :address => "smtp.gmail.com",
     :port => 587,
     :domain => 'smtp.gmail.com',
-    :user_name => Settings.development[:email], #先ほど作成した送信用Gmailアドレス
-    :password => Settings.development[:password], #2段階認証したアカウントで発行したアプリパスワード
+    :user_name => "Settings.development[:email]", #先ほど作成した送信用Gmailアドレス
+    :password => "Settings.development[:password]", #2段階認証したアカウントで発行したアプリパスワード
     :authentication => 'login'
   }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,5 +44,5 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   
-    config.action_mailer.default_url_options = { host: Settings.development[:url] }
+    # config.action_mailer.default_url_options = { host: Settings.development[:url] }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = Settings.development[:email]
+  config.mailer_sender = "Settings.development[:email]"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
circleci のdb:createでNoMethodError: undefined method ()' for nil:NilClassのエラー
configでSetting.***[:***]の[]を読めていないことが原因だった。
そのためSettingの部分をダブルコーテーションで囲むことで修正したが、
少々面倒